### PR TITLE
refactor: find_imports logic about named import

### DIFF
--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -2,8 +2,15 @@ use code_explorer::CodeExplorer as CodeExplorerImpl;
 use napi_derive::napi;
 
 #[napi(object)]
+pub struct ImportBinding {
+  pub local: String,
+  pub imported: String,
+  pub is_type: bool,
+}
+
+#[napi(object)]
 pub struct ImportResults {
-  pub ids: Vec<String>,
+  pub bindings: Vec<ImportBinding>,
   pub source: String,
 }
 
@@ -27,8 +34,15 @@ impl CodeExplorer {
       .inner
       .find_imports()
       .into_iter()
-      .map(|(source, ids)| ImportResults {
-        ids: ids.ids,
+      .map(|(source, bds)| ImportResults {
+        bindings: bds
+          .into_iter()
+          .map(|b| ImportBinding {
+            local: b.local,
+            imported: b.imported,
+            is_type: b.is_type,
+          })
+          .collect(),
         source,
       })
       .collect()

--- a/crates/core/src/core_explorer.rs
+++ b/crates/core/src/core_explorer.rs
@@ -1,6 +1,6 @@
 mod find_imports;
 
-pub use find_imports::{find_imports, ImportStmt};
+pub use find_imports::{find_imports, ImportBinding};
 use std::collections::HashMap;
 use tree_sitter::{Parser, Tree};
 
@@ -27,7 +27,7 @@ impl CodeExplorer {
     }
   }
 
-  pub fn find_imports(&self) -> HashMap<String, ImportStmt> {
+  pub fn find_imports(&self) -> HashMap<String, Vec<ImportBinding>> {
     find_imports(&self.raw_code, &self.tree)
   }
 }

--- a/packages/code-explorer/src/binding.d.ts
+++ b/packages/code-explorer/src/binding.d.ts
@@ -6,8 +6,14 @@ export class CodeExplorer {
   findImports(): Array<ImportResults>
 }
 
+export interface ImportBinding {
+  local: string
+  imported: string
+  isType: boolean
+}
+
 export interface ImportResults {
-  ids: Array<string>
+  bindings: Array<ImportBinding>
   source: string
 }
 

--- a/packages/test/src/index.test.ts
+++ b/packages/test/src/index.test.ts
@@ -2,16 +2,61 @@ import { CodeExplorer } from 'code-explorer'
 
 it('find imports with CodeExplorer', () => {
   const code = `
-    import { foo } from 'bar'
+    import { a, b as bb, type c, type d as dd } from 's1'
+    import type { o, p as pp, type q, type r as rr } from 's2'
   `
   const res = new CodeExplorer(code).findImports()
   expect(res).toMatchInlineSnapshot(`
     [
       {
-        "ids": [
-          "foo",
+        "bindings": [
+          {
+            "imported": "a",
+            "isType": false,
+            "local": "a",
+          },
+          {
+            "imported": "b",
+            "isType": false,
+            "local": "bb",
+          },
+          {
+            "imported": "c",
+            "isType": true,
+            "local": "c",
+          },
+          {
+            "imported": "d",
+            "isType": true,
+            "local": "dd",
+          },
         ],
-        "source": "'bar'",
+        "source": "'s1'",
+      },
+      {
+        "bindings": [
+          {
+            "imported": "o",
+            "isType": true,
+            "local": "o",
+          },
+          {
+            "imported": "p",
+            "isType": true,
+            "local": "pp",
+          },
+          {
+            "imported": "q",
+            "isType": true,
+            "local": "q",
+          },
+          {
+            "imported": "r",
+            "isType": true,
+            "local": "rr",
+          },
+        ],
+        "source": "'s2'",
       },
     ]
   `)


### PR DESCRIPTION
## description

Hi, @alexzhang1030. This PR is to refactor the logic of `find_imports` about `named import`.

Some problems need to be paid attention to:

- how to use the `#[napi]` macro on the structs defined in the core but used in the bindings
- better code design on perf ( currently the codes are just able to run 😂 )

